### PR TITLE
Remove `aud` requirement for new-style WorkOS accounts in auth.config.ts

### DIFF
--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -14,7 +14,6 @@ const authConfig = {
       issuer: `https://api.workos.com/user_management/${clientId}`,
       algorithm: 'RS256',
       jwks: `https://api.workos.com/sso/jwks/${clientId}`,
-      applicationID: clientId,
     },
   ],
 };


### PR DESCRIPTION
This makes editing the JWT template no longer necessary, which is fine when the issuer is unique.