### PR TITLE
Explicit opt-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "license": "MIT",
   "homepage": "https://github.com:workos/template-convex-react-vite-authkit/#readme",
+  "convex-authkit-auto-provisioning": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com:workos/template-convex-react-vite-authkit.git"
@@ -24,7 +25,7 @@
   },
   "dependencies": {
     "@workos-inc/authkit-react": "^0.11.0",
-    "convex": "^1.27.2",
+    "convex": "^1.27.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
Until this is the primary supported way to configure AuthKit so supports all the ways it's already used, let's use an opt-in signaling that Convex knows how to configure this template.